### PR TITLE
Restore kernel query fallback for CoreOS 43

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,12 +25,15 @@ jobs:
       zfs-available: ${{ steps.check-zfs.outputs.available }}
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
       - name: Query kernel version from CoreOS container labels
         id: kernel-info
         run: |
-          # Get kernel version from remote container labels (no pull required!)
-          KERNEL_VERSION=$(skopeo inspect docker://quay.io/fedora/fedora-coreos:stable | jq -r '.Labels."ostree.linux"')
-          
+          # Get kernel version from remote container, falling back to rpm query when labels are missing
+          KERNEL_VERSION=$(./scripts/query-coreos-kernel.sh)
+
           echo "kernel-version=$KERNEL_VERSION" >> $GITHUB_OUTPUT
           echo "Found kernel version: $KERNEL_VERSION"
 

--- a/scripts/query-coreos-kernel.sh
+++ b/scripts/query-coreos-kernel.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE="${1:-quay.io/fedora/fedora-coreos:stable}"
+CONTAINER_CLI="${CONTAINER_CLI:-}"
+
+if [[ -z "${CONTAINER_CLI}" ]]; then
+  if command -v podman >/dev/null 2>&1; then
+    CONTAINER_CLI="podman"
+  elif command -v docker >/dev/null 2>&1; then
+    CONTAINER_CLI="docker"
+  else
+    CONTAINER_CLI=""
+  fi
+fi
+
+INSPECT_OUTPUT=$(skopeo inspect "docker://${IMAGE}")
+DIGEST=$(jq -r '.Digest' <<<"${INSPECT_OUTPUT}")
+if [[ -n "${DIGEST}" && "${DIGEST}" != "null" ]]; then
+  IMAGE_WITH_DIGEST="${IMAGE}@${DIGEST}"
+else
+  IMAGE_WITH_DIGEST="${IMAGE}"
+fi
+
+KERNEL_VERSION=$(jq -r '.Labels["ostree.linux"]' <<<"${INSPECT_OUTPUT}")
+
+if [[ -z "${KERNEL_VERSION}" || "${KERNEL_VERSION}" == "null" ]]; then
+  if [[ -z "${CONTAINER_CLI}" ]]; then
+    echo "Failed to determine kernel version from ${IMAGE} and no container runtime available for fallback" >&2
+    exit 1
+  fi
+
+  if ! RPM_QUERY_OUTPUT=$("${CONTAINER_CLI}" run --rm --entrypoint rpm "${IMAGE_WITH_DIGEST}" \
+    -q kernel-core --qf '%{VERSION}-%{RELEASE}.%{ARCH}\n'); then
+    echo "Failed to run rpm fallback inside ${IMAGE}" >&2
+    exit 1
+  fi
+
+  KERNEL_VERSION=$(head -n1 <<<"${RPM_QUERY_OUTPUT}" | tr -d '\r')
+fi
+
+echo "${KERNEL_VERSION}"


### PR DESCRIPTION
## Summary
- ensure the query-versions job checks out the repository and uses a script to discover the CoreOS kernel version
- add a helper script that reads the kernel label and falls back to an rpm query when CoreOS omits the label

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917bf05e1e88329a79ee260e24312d6)