### PR TITLE
Switch to nftables firewall

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -38,7 +38,7 @@ RUN --mount=type=bind,from=zfs-rpms,source=/,target=/zfs-rpms \
         cockpit-ostree \
         cockpit-podman \
         cockpit-system \
-        firewalld \
+        nftables \
         tailscale \
         /zfs-rpms/*.noarch.rpm \
         /zfs-rpms/other/zfs-dracut-*.noarch.rpm \
@@ -46,10 +46,9 @@ RUN --mount=type=bind,from=zfs-rpms,source=/,target=/zfs-rpms \
     depmod -a "$(rpm -qa kernel --queryformat "%{VERSION}-%{RELEASE}.%{ARCH}")"; \
     echo "zfs" > /etc/modules-load.d/zfs.conf; \
     rm -rf /var/lib/pcp /var/cache/dnf; \
-    systemctl unmask firewalld; \
     systemctl enable \
         bootc-fetch-apply-updates.service \
-        firewalld.service \
+        nftables.service \
         tailscaled.service \
         zfs-health-check.timer \
         zfs-scrub-monthly@tank.timer \

--- a/overlay-root/etc/sysconfig/nftables.conf
+++ b/overlay-root/etc/sysconfig/nftables.conf
@@ -1,0 +1,40 @@
+#!/usr/sbin/nft -f
+
+flush ruleset
+
+define private_v4 = { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 }
+define private_v6 = { fc00::/7 }
+define lan_ifaces = { "en*", "eth*", "eno*", "ens*", "enp*", "wl*" }
+
+table inet filter {
+    chain input {
+        type filter hook input priority 0; policy drop;
+
+        # Connection tracking and local system access
+        ct state established,related accept
+        iif lo accept
+
+        # Allow all traffic from the Tailscale network interface
+        iifname "tailscale0" accept
+
+        # DHCP for IPv4 and IPv6 clients
+        ip protocol udp udp sport 67 udp dport 68 accept
+        ip6 nexthdr udp udp sport 547 udp dport 546 accept
+
+        # SSH from private address space on common LAN interface names
+        iifname $lan_ifaces ip saddr $private_v4 tcp dport 22 accept
+        iifname $lan_ifaces ip6 saddr $private_v6 tcp dport 22 accept
+
+        # ICMP for diagnostics and IPv6 neighbor discovery
+        ip protocol icmp accept
+        ip6 nexthdr icmpv6 accept
+    }
+
+    chain forward {
+        type filter hook forward priority 0; policy drop;
+    }
+
+    chain output {
+        type filter hook output priority 0; policy accept;
+    }
+}


### PR DESCRIPTION
## Summary
- replace firewalld with nftables and enable the nftables service
- add declarative nftables rules for tailscale, SSH from private ranges, DHCP, and ICMP traffic

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956b4207bf88329a17f6c12c4b54ac6)