### PR TITLE
Upgrade ZFS version filter from 2.3.x to 2.4.x

### DIFF
--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -39,7 +39,7 @@ jobs:
           ZFS_VERSION=$(gh release list \
               --repo openzfs/zfs \
               --json publishedAt,tagName \
-              --jq '[.[] | select(.tagName | startswith("zfs-2.3"))] | sort_by(.publishedAt) | last | .tagName' \
+              --jq '[.[] | select(.tagName | startswith("zfs-2.4"))] | sort_by(.publishedAt) | last | .tagName' \
               --limit 100)
           ZFS_VERSION_CLEAN=${ZFS_VERSION#zfs-}
           echo "zfs-version=$ZFS_VERSION_CLEAN" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,11 +42,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Get the latest ZFS 2.3.x release
+          # Get the latest ZFS 2.4.x release
           ZFS_VERSION=$(gh release list \
               --repo openzfs/zfs \
               --json publishedAt,tagName \
-              --jq '[.[] | select(.tagName | startswith("zfs-2.3"))] | sort_by(.publishedAt) | last | .tagName' \
+              --jq '[.[] | select(.tagName | startswith("zfs-2.4"))] | sort_by(.publishedAt) | last | .tagName' \
               --limit 100)
           
           # Extract just the version part for container tag

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ This project depends on `../fedora-zfs-kmods/` which builds and publishes prebui
 
 ### Version Discovery & Compatibility
 - `just versions` - Show ZFS, kernel versions and compatibility status
-- `just zfs-version` - Get latest ZFS 2.3.x release
+- `just zfs-version` - Get latest ZFS 2.4.x release
 - `just kernel-version` - Get current CoreOS kernel version (script-based fallback if labels are missing)
 - `just check-zfs-available` - Verify prebuilt ZFS kmods exist for current versions
 

--- a/Justfile
+++ b/Justfile
@@ -3,12 +3,12 @@
 _default:
     @just --list
 
-# Get the latest ZFS 2.3.x version tag
+# Get the latest ZFS 2.4.x version tag
 zfs-version:
     gh release list \
         --repo openzfs/zfs \
         --json publishedAt,tagName \
-        --jq '[.[] | select(.tagName | startswith("zfs-2.3"))] | sort_by(.publishedAt) | last | .tagName' \
+        --jq '[.[] | select(.tagName | startswith("zfs-2.4"))] | sort_by(.publishedAt) | last | .tagName' \
         --limit 100
 
 # Get kernel version from Fedora CoreOS stable with fallback when labels are missing

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ just all-workflows     # All workflows
 just check-zfs-available
 
 # View version information
-just zfs-version         # Latest ZFS 2.3.x
+just zfs-version         # Latest ZFS 2.4.x
 just kernel-version      # Current CoreOS kernel (script-based fallback if labels are missing)
 just versions           # All versions + compatibility
 


### PR DESCRIPTION
The fedora-zfs-kmods repo now builds ZFS 2.4.0, which adds support
for Linux kernel 6.18 (used by current CoreOS). ZFS 2.3.x only
supports up to kernel 6.17.

Updates the version prefix filter in all version discovery locations:
- Justfile (zfs-version recipe)
- build.yaml (CI build workflow)
- build-check.yaml (CI check workflow)
- README.md and AGENTS.md (documentation)

https://claude.ai/code/session_014v4hZyJPv6ou7kcnWbP6Sg