### PR TITLE
Remove nfs-utils-coreos removal step, no longer in Fedora 44 base image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -88,7 +88,6 @@ RUN --mount=type=bind,from=zfs-rpms,source=/,target=/zfs-rpms \
     # Validate that provided kernel version matches actual CoreOS kernel \
     [[ "$(rpm -qa kernel --queryformat "%{VERSION}-%{RELEASE}.%{ARCH}")" == "${KERNEL_VERSION}" ]]; \
     arch="$(rpm -qa kernel --queryformat "%{ARCH}")"; \
-    rpm -e --nodeps nfs-utils-coreos; \
     dnf install -y \
         cockpit-bridge \
         cockpit-kdump \


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Fedora CoreOS stable moved to Fedora 44, which replaced `nfs-utils-coreos` with `nfs-client-utils` (the new package RPM-obsoletes the old one)
- The base image no longer has `nfs-utils-coreos` installed, so `rpm -e --nodeps nfs-utils-coreos` was failing and aborting the build under `set -euo pipefail`
- Fix is a one-line deletion — that removal step is no longer needed since the upstream packaging change already resolved the file conflict that originally motivated it

## Test plan

- [ ] Trigger a build workflow run and confirm the image builds successfully against the current stable CoreOS (Fedora 44)

https://claude.ai/code/session_013aSMzfQMjkXB9cofsqMKT6
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_013aSMzfQMjkXB9cofsqMKT6)_