### PR TITLE
Bound Garage boot-time storage checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,7 +275,7 @@ Useful reference points for future rootless work:
 - vmalert's shipped rules now live under `/usr/share/custom-coreos/vmalert/` so they remain image-controlled rather than service-owned
 - Alertmanager's static config lives under `/usr/share/custom-coreos/alertmanager/` and uses native Pushover `user_key_file` / `token_file` settings; do not reintroduce plaintext config generation under `/var`
 - VictoriaMetrics' scrape config lives under `/usr/share/custom-coreos/victoria-metrics/`; its large ZFS data path is prepared by `zfs-create-victoria-metrics-dataset.service`, not recursive generator-managed tmpfiles rules
-- Garage's config lives under `/usr/share/custom-coreos/garage/`; its two ZFS paths use a fixed recursive rollback snapshot and guarded root-last ownership migration in `zfs-create-garage-datasets.service`
+- Garage's config lives under `/usr/share/custom-coreos/garage/`; its two ZFS paths use a fixed recursive rollback snapshot and guarded root-last ownership migration in `zfs-create-garage-datasets.service`. Normal boots check only roots and bounded samples; create `/var/lib/nas-migrations/garage-rootless-ownership-v1/repair-required` before restarting the preparation service when an explicit full recursive ownership and SELinux repair is required.
 - Caddy's first-stage preflight must not declare its live state paths through the generator's `[data]` section; the generated recursive tmpfiles ownership rule would mutate the rootful deployment
 - For rootless Grafana, SELinux access is intended to come from persistent `semanage fcontext` rules plus `restorecon`, not from `SecurityLabelDisable=true`
 

--- a/docs/rootless-garage-checklist.md
+++ b/docs/rootless-garage-checklist.md
@@ -80,10 +80,38 @@ Both paths must have owner `_nas_garage:_nas_garage`, mode `0750`, and the
 SELinux context `container_file_t:s0`. The snapshot listing must contain the
 parent, metadata, and data snapshots with the same fixed name.
 
-The preparation unit has no timeout and retries every 30 seconds. The user
-service waits up to one hour for its current-boot marker, exact mounts, owners,
-and write access. If `tank` was imported late, let the automatic retry recover;
-otherwise restart only the preparation unit and inspect its journal.
+The preparation unit has no timeout and retries every 30 seconds. On normal
+boots it checks only the dataset roots and one immediate descendant from each
+tree; it does not recursively scan the object store. The user service waits up
+to one hour for its current-boot marker, exact mounts, owners, and write access.
+If `tank` was imported late, let the automatic retry recover; otherwise restart
+only the preparation unit and inspect its journal.
+
+A recursive ownership and SELinux repair is deliberately explicit because it
+can take tens of minutes. With Garage stopped, request one by creating the
+durable marker and restarting the preparation unit:
+
+```bash
+sudo -u _nas_garage env \
+  HOME=/var/home/_nas_garage \
+  XDG_RUNTIME_DIR=/run/user/51110 \
+  DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/51110/bus \
+  bash -lc 'cd / && systemctl --user stop garage.service'
+sudo install -d -m 0700 -o root -g root \
+  /var/lib/nas-migrations/garage-rootless-ownership-v1
+sudo touch \
+  /var/lib/nas-migrations/garage-rootless-ownership-v1/repair-required
+sudo systemctl restart zfs-create-garage-datasets.service && \
+sudo -u _nas_garage env \
+  HOME=/var/home/_nas_garage \
+  XDG_RUNTIME_DIR=/run/user/51110 \
+  DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/51110/bus \
+  bash -lc 'cd / && systemctl --user start garage.service'
+```
+
+The marker is removed only after both complete recursive passes succeed. Do
+not start Garage manually while the preparation service is running; the
+foreground `systemctl restart` must return successfully first.
 
 ## 4. Runtime Secrets
 
@@ -177,10 +205,10 @@ Its timer, service, and executable are no longer present in the image.
 
 A bootc rollback alone does not require reversing ownership: the old rootful
 container can access UID `51110` files, and its SOPS manifest recreates the
-rootful Podman secrets at boot. If the rootful deployment writes new `0:0`
-files and you later redeploy the rootless image, the preparation service
-detects that descendant drift and automatically repeats the affected root-last
-ownership pass before publishing readiness.
+rootful Podman secrets at boot. If that deployment writes new `0:0` files,
+create the `repair-required` marker before returning Garage to service on the
+rootless image. Normal boots intentionally do not search the entire object
+store for deep ownership drift.
 
 For a data rollback while remaining on the rootless image, use this sequence:
 
@@ -205,4 +233,7 @@ Keep both Garage services stopped while rolling metadata and data back to the
 matching snapshots. A ZFS rollback is not atomic across datasets. The commands
 above fail rather than destroy newer snapshots; review and preserve any newer
 snapshots instead of casually adding `-r`. Dataset preparation reapplies
-ownership and labels before the user service can pass its readiness gate.
+ownership and labels before the user service can pass its readiness gate. The
+pre-rootless snapshots restore root-owned dataset roots, which automatically
+selects the interrupted-repair path; other rollback points may require the
+explicit `repair-required` marker.

--- a/docs/rootless-quadlet-playbook.md
+++ b/docs/rootless-quadlet-playbook.md
@@ -74,8 +74,11 @@ The repo now has six concrete rootless examples:
 
   Its fixed recursive ZFS snapshot establishes one rollback point for metadata
   and blocks before either tree is changed. Both dataset roots act as durable
-  completion markers, and the user service independently verifies mounts,
-  ownership, write access, secrets, and host-port availability before starting.
+  completion markers. Normal boots validate only roots and bounded samples;
+  full recursive repair requires an initial/interrupted migration or an
+  explicit durable repair request. The user service independently verifies
+  mounts, ownership, write access, secrets, and host-port availability before
+  starting.
 
 - Caddy is the staged-migration example. Its `quadlets/caddy.toml` entry uses
   `enabled = false` during the rootful preflight release. This reserves the

--- a/overlay-root/usr/local/bin/zfs-create-garage-datasets.sh
+++ b/overlay-root/usr/local/bin/zfs-create-garage-datasets.sh
@@ -28,6 +28,7 @@ ROLLBACK_SNAPSHOT="pre-rootless-v1"
 PREFLIGHT_COMPLETE="/var/lib/nas-migrations/garage-rootless-preflight-v1/complete"
 MIGRATION_DIR="/var/lib/nas-migrations/garage-rootless-ownership-v1"
 MIGRATION_COMPLETE="${MIGRATION_DIR}/complete"
+REPAIR_REQUEST="${MIGRATION_DIR}/repair-required"
 
 log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
@@ -52,7 +53,7 @@ sample_descendant() {
     local path="$1"
 
     find "${path}" -xdev -mindepth 1 -maxdepth 1 \
-        ! -path "${path}/.zfs" -print -quit 2>/dev/null
+        ! -path "${path}/.zfs" -print -quit
 }
 
 labels_are_ready() {
@@ -63,8 +64,44 @@ labels_are_ready() {
         return 1
     fi
 
-    sample="$(sample_descendant "${path}")"
+    if ! sample="$(sample_descendant "${path}")"; then
+        return 1
+    fi
     [[ -z "${sample}" || "$(stat -c '%C' "${sample}")" == "${EXPECTED_LABEL}" ]]
+}
+
+sample_owner_is_ready() {
+    local path="$1"
+    local sample
+
+    if ! sample="$(sample_descendant "${path}")"; then
+        return 1
+    fi
+    [[ -z "${sample}" || "$(stat -c '%u:%g' "${sample}")" == "${SERVICE_UID}:${SERVICE_GID}" ]]
+}
+
+bounded_state_is_ready() {
+    local path="$1"
+
+    if [[ "$(stat -c '%u:%g' "${path}")" != "${SERVICE_UID}:${SERVICE_GID}" ]]; then
+        log "ERROR: ${path} root is not owned by ${SERVICE_UID}:${SERVICE_GID}"
+        return 1
+    fi
+
+    if [[ "$(stat -c '%a' "${path}")" != "750" ]]; then
+        log "ERROR: ${path} root mode is not 0750"
+        return 1
+    fi
+
+    if ! labels_are_ready "${path}"; then
+        log "ERROR: ${path} root or bounded sample has an unexpected SELinux label"
+        return 1
+    fi
+
+    if ! sample_owner_is_ready "${path}"; then
+        log "ERROR: ${path} bounded sample has unexpected ownership"
+        return 1
+    fi
 }
 
 restorecon_recursive() {
@@ -114,16 +151,57 @@ validate_root_owner() {
     fi
 }
 
-ensure_garage_stopped() {
-    local rootful_running
+rootless_podman() {
+    runuser -u "${SERVICE_USER}" -- env \
+        HOME="/var/home/${SERVICE_USER}" \
+        XDG_RUNTIME_DIR="/run/user/${SERVICE_UID}" \
+        podman "$@"
+}
 
-    rootful_running="$(podman inspect garage --format '{{.State.Running}}' 2>/dev/null || true)"
-    if [[ "${rootful_running}" == "true" ]]; then
-        log "ERROR: Refusing to mutate Garage storage while the rootful container is running"
-        exit 1
+ensure_garage_stopped() {
+    local exists_status
+    local listeners
+    local running
+
+    if podman container exists garage >/dev/null 2>&1; then
+        if ! running="$(podman inspect garage --format '{{.State.Running}}')"; then
+            log "ERROR: Unable to inspect the rootful Garage container"
+            exit 1
+        fi
+        if [[ "${running}" == "true" ]]; then
+            log "ERROR: Refusing to mutate Garage storage while the rootful container is running"
+            exit 1
+        fi
+    else
+        exists_status=$?
+        if [[ "${exists_status}" -ne 1 ]]; then
+            log "ERROR: Unable to query the rootful Podman store for Garage"
+            exit 1
+        fi
     fi
 
-    if ss -H -ltn | awk '$4 ~ /:390(0|2|3)$/ { found=1 } END { exit !found }'; then
+    if rootless_podman container exists garage >/dev/null 2>&1; then
+        if ! running="$(rootless_podman inspect garage --format '{{.State.Running}}')"; then
+            log "ERROR: Unable to inspect the rootless Garage container"
+            exit 1
+        fi
+        if [[ "${running}" == "true" ]]; then
+            log "ERROR: Refusing to mutate Garage storage while the rootless container is running"
+            exit 1
+        fi
+    else
+        exists_status=$?
+        if [[ "${exists_status}" -ne 1 ]]; then
+            log "ERROR: Unable to query ${SERVICE_USER}'s Podman store for Garage"
+            exit 1
+        fi
+    fi
+
+    if ! listeners="$(ss -H -ltn)"; then
+        log "ERROR: Unable to inspect Garage host ports"
+        exit 1
+    fi
+    if awk '$4 ~ /:390(0|2|3)$/ { found=1 } END { exit !found }' <<< "${listeners}"; then
         log "ERROR: Refusing to mutate Garage storage while a process listens on a Garage host port"
         exit 1
     fi
@@ -166,19 +244,6 @@ verify_descendant_owners() {
     local path="$1"
     local unexpected
 
-    unexpected="$(find "${path}" -xdev -path "${path}/.zfs" -prune -o \
-        -mindepth 1 \( ! -uid "${SERVICE_UID}" -o ! -gid "${SERVICE_GID}" \) \
-        -print -quit 2>/dev/null)"
-    if [[ -n "${unexpected}" ]]; then
-        log "ERROR: ${unexpected} does not have expected owner ${SERVICE_UID}:${SERVICE_GID}"
-        exit 1
-    fi
-}
-
-descendant_owners_are_ready() {
-    local path="$1"
-    local unexpected
-
     if ! unexpected="$(find "${path}" -xdev -path "${path}/.zfs" -prune -o \
         -mindepth 1 \( ! -uid "${SERVICE_UID}" -o ! -gid "${SERVICE_GID}" \) \
         -print -quit)"; then
@@ -186,7 +251,10 @@ descendant_owners_are_ready() {
         exit 1
     fi
 
-    [[ -z "${unexpected}" ]]
+    if [[ -n "${unexpected}" ]]; then
+        log "ERROR: ${unexpected} does not have expected owner ${SERVICE_UID}:${SERVICE_GID}"
+        exit 1
+    fi
 }
 
 prepare_dataset() {
@@ -304,48 +372,43 @@ validate_root_owner "${META_PATH}"
 validate_root_owner "${DATA_PATH}"
 ensure_garage_stopped
 
-migration_needed=0
-repair_meta_descendants=0
-repair_data_descendants=0
-if [[ "$(stat -c '%u:%g' "${META_PATH}")" != "${SERVICE_UID}:${SERVICE_GID}" || \
-      "$(stat -c '%u:%g' "${DATA_PATH}")" != "${SERVICE_UID}:${SERVICE_GID}" ]]; then
-    migration_needed=1
-fi
-if ! descendant_owners_are_ready "${META_PATH}"; then
-    log "Ownership drift detected under ${META_PATH}; scheduling a full repair"
-    repair_meta_descendants=1
-    migration_needed=1
-fi
-if ! descendant_owners_are_ready "${DATA_PATH}"; then
-    log "Ownership drift detected under ${DATA_PATH}; scheduling a full repair"
-    repair_data_descendants=1
-    migration_needed=1
-fi
-
+preparation_mode="normal"
 if [[ ! -e "${MIGRATION_COMPLETE}" ]]; then
+    preparation_mode="initial"
     if { path_has_entries "${META_PATH}" || path_has_entries "${DATA_PATH}"; } && \
        [[ ! -e "${PREFLIGHT_COMPLETE}" ]]; then
         log "ERROR: Existing Garage data requires the completed rootless preflight report"
         exit 1
     fi
     ensure_rollback_snapshot
-elif [[ "${migration_needed}" -eq 1 ]]; then
-    log "Repairing an interrupted post-migration ownership or label operation"
+elif [[ -e "${REPAIR_REQUEST}" ]]; then
+    preparation_mode="requested-repair"
+elif [[ "$(stat -c '%u:%g' "${META_PATH}")" == "0:0" || \
+        "$(stat -c '%u:%g' "${DATA_PATH}")" == "0:0" ]]; then
+    preparation_mode="interrupted-repair"
 fi
 
-# A bootc rollback can run rootful Garage against roots that retain UID 51110,
-# creating new root-owned descendants. Re-arm only the affected root markers
-# after Garage is confirmed stopped so the normal root-last transaction repairs
-# those trees before readiness is published.
-if [[ "${repair_meta_descendants}" -eq 1 ]]; then
-    chown root:root "${META_PATH}"
-fi
-if [[ "${repair_data_descendants}" -eq 1 ]]; then
-    chown root:root "${DATA_PATH}"
-fi
+if [[ "${preparation_mode}" == "normal" ]]; then
+    # Static service IDs make a recursive ownership scan unnecessary during an
+    # ordinary rootless boot. Check roots and one immediate descendant only.
+    # Deep repair is an explicit operation because it can take tens of minutes.
+    for path in "${META_PATH}" "${DATA_PATH}"; do
+        if ! bounded_state_is_ready "${path}"; then
+            log "ERROR: Refusing an implicit full-tree scan. To request repair, create ${REPAIR_REQUEST} and restart this service"
+            exit 1
+        fi
+    done
+    log "Garage dataset roots and bounded samples are ready; skipped recursive ownership scan"
+else
+    log "Running full Garage dataset preparation (${preparation_mode})"
 
-prepare_dataset "${META_PATH}"
-prepare_dataset "${DATA_PATH}"
+    # Arm both dataset roots before a requested or initial full pass. Their
+    # root ownership remains the durable incomplete-operation marker until all
+    # descendant ownership and labels have been verified.
+    chown root:root "${META_PATH}" "${DATA_PATH}"
+    prepare_dataset "${META_PATH}"
+    prepare_dataset "${DATA_PATH}"
+fi
 
 for path in "${META_PATH}" "${DATA_PATH}"; do
     if [[ "$(stat -c '%u:%g' "${path}")" != "${SERVICE_UID}:${SERVICE_GID}" || \
@@ -358,6 +421,10 @@ done
 if [[ ! -e "${MIGRATION_COMPLETE}" ]]; then
     install -d -m 0700 -o root -g root "${MIGRATION_DIR}"
     touch "${MIGRATION_COMPLETE}"
+fi
+
+if [[ "${preparation_mode}" == "requested-repair" ]]; then
+    rm -f "${REPAIR_REQUEST}"
 fi
 
 log "Garage ZFS datasets ready"

--- a/tests/test_garage_dataset_preparation.py
+++ b/tests/test_garage_dataset_preparation.py
@@ -1,0 +1,63 @@
+# ABOUTME: Regression tests for Garage's bounded normal-boot storage checks.
+
+import unittest
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = (
+    REPO / "overlay-root/usr/local/bin/zfs-create-garage-datasets.sh"
+).read_text()
+
+
+class GarageDatasetPreparationTests(unittest.TestCase):
+    def test_normal_boot_has_no_recursive_preparation_or_ownership_scan(self):
+        marker = 'if [[ "${preparation_mode}" == "normal" ]]'
+        normal_branch = SCRIPT.split(marker, 1)[1].split("\nelse\n", 1)[0]
+
+        self.assertIn('bounded_state_is_ready "${path}"', normal_branch)
+        self.assertNotIn("prepare_dataset", normal_branch)
+        self.assertNotIn("verify_descendant_owners", normal_branch)
+        self.assertNotIn("restorecon_recursive", normal_branch)
+        self.assertNotIn("find ", normal_branch)
+
+    def test_bounded_sample_is_constant_depth(self):
+        sample_function = SCRIPT.split("sample_descendant() {", 1)[1].split(
+            "\n}\n", 1
+        )[0]
+
+        self.assertIn("-mindepth 1 -maxdepth 1", sample_function)
+        self.assertIn("-print -quit", sample_function)
+
+    def test_full_repair_requires_durable_state(self):
+        self.assertIn(
+            'REPAIR_REQUEST="${MIGRATION_DIR}/repair-required"', SCRIPT
+        )
+        self.assertIn('elif [[ -e "${REPAIR_REQUEST}" ]]', SCRIPT)
+        self.assertIn('preparation_mode="requested-repair"', SCRIPT)
+        self.assertIn('rm -f "${REPAIR_REQUEST}"', SCRIPT)
+
+    def test_recursive_verification_fails_when_find_fails(self):
+        verification = SCRIPT.split("verify_descendant_owners() {", 1)[1].split(
+            "\n}\n", 1
+        )[0]
+
+        self.assertIn('if ! unexpected="$(find ', verification)
+        self.assertIn("Unable to verify ownership", verification)
+
+    def test_unconditional_descendant_scan_regression_is_absent(self):
+        self.assertNotIn("descendant_owners_are_ready", SCRIPT)
+
+    def test_mutation_guard_checks_both_stores_and_fails_closed(self):
+        guard = SCRIPT.split("ensure_garage_stopped() {", 1)[1].split(
+            "\n}\n", 1
+        )[0]
+
+        self.assertIn("podman container exists garage", guard)
+        self.assertIn("rootless_podman container exists garage", guard)
+        self.assertIn('if ! listeners="$(ss -H -ltn)"', guard)
+        self.assertIn("Unable to inspect Garage host ports", guard)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- replace unconditional full-tree Garage ownership scans with bounded root and immediate-descendant checks on normal boots
- retain recursive root-last preparation for initial migrations, interrupted operations, and durable explicit repair requests
- add an explicit `repair-required` workflow for rootful rollback or detected deep drift
- make ownership verification and Garage stopped-state checks fail closed
- document the new repair and rollback behavior
- add regression tests that prevent an unbounded traversal from returning to the normal path

## Root cause

The rootless Garage cutover added `descendant_owners_are_ready` checks before consulting the completed migration marker. Those checks recursively walked both ZFS trees on every boot, delaying Garage readiness by roughly 30 minutes on the production object dataset.

## Impact

Ordinary boots now perform only constant-depth checks. A potentially long recursive ownership and SELinux pass happens only for initial/interrupted migration state or after an administrator creates the durable repair marker.

## Validation

- `python3 -m unittest discover -s tests -v` (12 tests)
- `bash -n overlay-root/usr/local/bin/zfs-create-garage-datasets.sh`
- `shellcheck overlay-root/usr/local/bin/zfs-create-garage-datasets.sh`
- generated Quadlet drift check
- `make build`
- bootc container lint passed with only the repository's expected runtime/cache warnings
- verified the built image's dataset script SHA-256 matches the worktree