### PR TITLE
Record Caddy preflight validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ This repo is not just "CoreOS with ZFS". It currently defines a full single-node
 
 These are considered active and in use on the real machine unless explicitly stated otherwise:
 - `blackbox-exporter.container` - local HTTP/TCP probe exporter for service-availability checks; rootless under `etc/containers/systemd/users/51230/`
-- `caddy.container` - reverse proxy / TLS termination for the user-facing services; still rootful while its rootless preflight release is prepared
+- `caddy.container` - reverse proxy / TLS termination for the user-facing services; still rootful after its rootless preflight completed successfully, with the guarded phase-two cutover next
 - `garage.container` - S3-compatible object storage on ZFS; rootless under `etc/containers/systemd/users/51110/`, deployed and validated on the NAS
 - `victoria-metrics.container` - metrics storage; rootless under `etc/containers/systemd/users/51250/`, deployed and validated on the NAS
 - `vmalert.container` - alert rule evaluation; rootless under `etc/containers/systemd/users/51220/`
@@ -227,7 +227,7 @@ Images include labels for future deduplication:
 - `docs/rootless-victoria-metrics-checklist.md` - Post-boot validation for the VictoriaMetrics rootless, ZFS ownership, and runtime-secret migration
 - `docs/rootless-garage-preflight.md` - Historical first-stage evidence collection before Garage's rootless ownership migration
 - `docs/rootless-garage-checklist.md` - Post-boot validation and rollback steps for the Garage rootless, ZFS ownership, and runtime-secret migration
-- `docs/rootless-caddy-preflight.md` - First-stage validation for Caddy's rootless identity, runtime secret, low-port policy, and persistent state
+- `docs/rootless-caddy-preflight.md` - Completed first-stage validation and phase-two handoff for Caddy's rootless identity, runtime secret, low-port policy, persistent state, and guarded cutover
 - `vendored-docs/podman-systemd.unit.5.md` - Vendored Quadlet reference, useful for rootless/systemd placement questions
 - `docs/garage/configuration.md` - Vendored upstream Garage configuration reference
 
@@ -258,7 +258,7 @@ Images include labels for future deduplication:
 ## Rootless Quadlet Note
 
 Current state:
-- Caddy remains a rootful system Quadlet under `overlay-root/etc/containers/systemd/`; its rootless identity and runtime-secret preflight are staged with `quadlets/caddy.toml`, but `enabled = false` prevents generation of a user Quadlet
+- Caddy remains a rootful system Quadlet under `overlay-root/etc/containers/systemd/`; its rootless identity, runtime secret, low-port binding, state inventory, and representative routes were production-validated on 2026-07-21. `quadlets/caddy.toml` remains staged with `enabled = false`; the next task is the guarded phase-two cutover in `docs/rootless-caddy-preflight.md`.
 - Grafana, vmalert, blackbox exporter, Alertmanager, VictoriaMetrics, and Garage are deployed and validated as rootless admin-managed user Quadlets
 - Rootless-service files are **generated**: edit `quadlets/<service>.toml`, run `python3 generate-quadlets.py`, and commit both. Never hand-edit files with a `GENERATED` header — CI (`build-check.yaml` job `verify-generated`) fails on drift. Adding a new rootless service means: new TOML with a UID from the identity scheme below, run the generator, add `systemctl enable ensure-nas-<slug>-account.service` to the Containerfile, add any secret values to `secrets.sops.yaml`.
 
@@ -276,7 +276,7 @@ Useful reference points for future rootless work:
 - Alertmanager's static config lives under `/usr/share/custom-coreos/alertmanager/` and uses native Pushover `user_key_file` / `token_file` settings; do not reintroduce plaintext config generation under `/var`
 - VictoriaMetrics' scrape config lives under `/usr/share/custom-coreos/victoria-metrics/`; its large ZFS data path is prepared by `zfs-create-victoria-metrics-dataset.service`, not recursive generator-managed tmpfiles rules
 - Garage's config lives under `/usr/share/custom-coreos/garage/`; its two ZFS paths use a fixed recursive rollback snapshot and guarded root-last ownership migration in `zfs-create-garage-datasets.service`. Normal boots check only roots and bounded samples; create `/var/lib/nas-migrations/garage-rootless-ownership-v1/repair-required` before restarting the preparation service when an explicit full recursive ownership and SELinux repair is required.
-- Caddy's first-stage preflight must not declare its live state paths through the generator's `[data]` section; the generated recursive tmpfiles ownership rule would mutate the rootful deployment
+- Caddy's completed first-stage preflight must not declare its live state paths through the generator's `[data]` section; phase two needs a cutover-specific archive plus guarded descendant-first/root-last ownership and SELinux preparation service
 - For rootless Grafana, SELinux access is intended to come from persistent `semanage fcontext` rules plus `restorecon`, not from `SecurityLabelDisable=true`
 
 ## Build Performance

--- a/docs/plan-sops-and-quadlet-generator.md
+++ b/docs/plan-sops-and-quadlet-generator.md
@@ -1,10 +1,11 @@
 # Plan: SOPS Secrets Management and Quadlet Generator
 
-> **Implementation status (2026-07-20):** The SOPS distributor and Quadlet
+> **Implementation status (2026-07-21):** The SOPS distributor and Quadlet
 > generator described here are deployed. Grafana, vmalert, blackbox exporter,
 > Alertmanager, VictoriaMetrics, and Garage run as production-validated
-> rootless user Quadlets. Caddy remains rootful while its first-stage rootless
-> identity, runtime-secret, low-port, and state preflight is deployed.
+> rootless user Quadlets. Caddy remains rootful, but its first-stage rootless
+> identity, runtime-secret, low-port, state, and route preflight is deployed and
+> production-validated; the guarded phase-two cutover is next.
 > Alertmanager's migration was production-validated through a successful
 > synthetic Pushover notification. Sections written in the present tense under
 > "Background" and the phased rollout steps preserve the pre-implementation design history;

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -26,10 +26,10 @@ maintaining it.
    CI fails on drift. The TOMLs double as the secret-routing manifest for
    the distributor.
 
-4. **Everything migrates to rootless except possibly caddy.**
-   Caddy binds 80/443; either set `net.ipv4.ip_unprivileged_port_start=80`
-   or keep the edge proxy rootful. Rootful-caddy-plus-rootless-everything is
-   an acceptable end state.
+4. **Caddy will migrate rootless using the validated low-port policy.**
+   The production preflight confirmed that `_nas_caddy` can bind TCP and UDP
+   low ports with `net.ipv4.ip_unprivileged_port_start=80`. Phase two is a
+   guarded state/config/service cutover, not another feasibility decision.
 
 5. **Service UIDs are allocate-only.** Never reuse a retired UID; numeric
    file ownership (especially in ZFS snapshots) outlives the user. Scheme
@@ -48,6 +48,9 @@ maintaining it.
 - VictoriaMetrics and Garage migrated to rootless Quadlets and were validated
   on the NAS, including their guarded ZFS ownership conversions, preserved
   history/object state, runtime secrets, monitoring, and rollback paths.
+- Caddy's rootless preflight completed on the NAS on 2026-07-21. UID `51310`,
+  runtime-secret delivery, TCP/UDP low-port binding, rootful state inventory,
+  listeners, metrics, redirect, and Garage routing are production-validated.
 - Cockpit deleted (quadlet, packages, Caddy vhost).
 
 ## Remaining work (in order)
@@ -64,11 +67,9 @@ maintaining it.
       VictoriaMetrics becomes the real rootless consumer of that token.
 - [ ] **2. Finish the Caddy rootless migration.** Alertmanager,
       VictoriaMetrics, and Garage are production-validated. Caddy's first-stage
-      preflight release reserves UID `51310`, stages its runtime Cloudflare
-      token, applies the host low-port policy, and records the live rootful
-      state without generating or starting a rootless Caddy Quadlet. After the
-      preflight is deployed and validated, implement the guarded ownership,
-      SELinux, static-config, and reboot-based service cutover.
+      preflight is also deployed and validated. Next, implement the guarded
+      ownership, SELinux, static-config, and reboot-based service cutover using
+      the handoff in `docs/rootless-caddy-preflight.md`.
       Each migration: new TOML + UID allocation, secrets move from Podman
       `Secret=` to runtime files, then delete the rootful quadlet. When the
       last `Secret=` consumer is gone, delete the shell secret driver

--- a/docs/rootless-caddy-preflight.md
+++ b/docs/rootless-caddy-preflight.md
@@ -1,4 +1,10 @@
-# Caddy Rootless Migration Preflight
+# Caddy Rootless Migration Preflight (Completed)
+
+> **Production status (2026-07-21):** The preflight completed successfully on
+> the NAS. Rootful Caddy remained healthy throughout, and the successful report
+> is recorded under `/var/lib/nas-migrations/caddy-rootless-preflight-v1/`.
+> Phase two is the guarded reboot-based rootless cutover described at the end of
+> this document.
 
 Caddy is being migrated in two releases because it is the host's TLS edge,
 owns ACME account and certificate state, and is the only remaining rootful
@@ -84,6 +90,36 @@ sudo grep -H . \
 `state-inventory.txt` contains only paths and sizes, not file contents. It is
 root-readable migration evidence and does not need to be copied off the NAS.
 
+Confirm the durable completion marker with:
+
+```bash
+sudo test -e /var/lib/nas-migrations/caddy-rootless-preflight-v1/complete \
+  && echo "Caddy preflight complete"
+```
+
+## Production Findings
+
+The successful run established all of the following on the deployed NAS:
+
+- `_nas_caddy` is usable as UID/GID `51310`, has its reserved subordinate-ID
+  range, linger, an active user manager, and a working rootless Podman store
+- `net.ipv4.ip_unprivileged_port_start=80` permits direct TCP and UDP binding
+  by `_nas_caddy`; the ephemeral port range remains disjoint
+- the staged runtime Cloudflare token is readable by `_nas_caddy` and matches
+  the active rootful Podman secret without exposing either value
+- rootful Caddy uses the expected image, host networking, valid configuration,
+  TCP 80/443, UDP 443, metrics endpoint, redirect, and Garage health route
+- `/var/lib/caddy` and `/var/lib/caddy-config` are small root-owned trees with
+  `container_file_t` labels and private MCS categories from their current `:Z`
+  mounts
+
+The first run also found an obsolete
+`/var/lib/caddy/secrets/cf-api-token` owned by `1000:1000`. Its January 2026
+timestamps and differing content confirmed that it was neither active secret
+copy. It was removed before the successful rerun. The now-obsolete
+`/var/lib/caddy/secrets` tmpfiles declaration still needs to be removed during
+phase two.
+
 ## Failure And Rerun
 
 A failed command leaves the partial report but no `complete` marker. Inspect
@@ -101,8 +137,33 @@ sudo rm -f /var/lib/nas-migrations/caddy-rootless-preflight-v1/complete
 sudo systemctl start caddy-rootless-preflight.service
 ```
 
-Do not chown, relabel, move, stop, or manually replace any Caddy state during
-this stage. The cutover release will archive the two persistent trees, apply a
-guarded root-last ownership migration, install persistent SELinux policy, move
-the static Caddyfile into `/usr/share/custom-coreos/caddy/`, and retire the
-rootful Quadlet through a reboot.
+## Phase-Two Handoff
+
+Do not chown, relabel, move, stop, or manually replace Caddy state before the
+cutover implementation is ready. Phase two should be one reviewable,
+reboot-based transition with these elements:
+
+1. Archive the two small persistent trees before mutation and retain the
+   preflight report as the comparison baseline.
+2. Add a guarded preparation unit with a durable completion marker. It must
+   verify Caddy is stopped, migrate descendants first and roots last to
+   `51310:51310`, install persistent `container_file_t:s0` fcontext rules, and
+   use `restorecon -F -R` to clear the old private MCS categories.
+3. Move the static Caddyfile from `/etc/caddy/` into
+   `/usr/share/custom-coreos/caddy/` so it remains image-controlled.
+4. Complete `quadlets/caddy.toml`: enable generation, mount the image-controlled
+   Caddyfile, the two prepared state trees, and the runtime Cloudflare token;
+   retain host networking and add bounded readiness guards for the secret and
+   prepared state.
+5. Remove the rootful Caddy Quadlet and the preflight timer, service, script,
+   and Containerfile enablement in the same image. The reboot must leave only
+   the user-manager Caddy unit eligible to start.
+6. Remove the obsolete `/var/lib/caddy/secrets` tmpfiles declaration. Once
+   rootless Caddy is validated and no `Secret=` consumers remain, retire the
+   rootful shell secret-driver configuration, helpers, smoke test, and
+   `nas-secrets` wrapper.
+7. Validate TCP 80/443, UDP 443, metrics, representative HTTP/HTTPS routes,
+   certificate state, logs, rootless Podman identity, state ownership, and
+   `container_file_t:s0` labels. Provide a rollback procedure that restores the
+   archived trees and the prior bootc deployment without mixing ownership
+   states.


### PR DESCRIPTION
## What changed

- record the successful Caddy rootless preflight on the production NAS
- document the durable completion marker and validated identity, secret, low-port, listener, state, metrics, and routing evidence
- preserve the stale legacy Cloudflare-token finding and cleanup
- turn the completed preflight document into a concrete phase-two handoff
- update the roadmap, implementation plan, and agent guidance to identify the guarded rootless cutover as the next task

## Why

The first-stage preflight completed successfully on 2026-07-21. Recording the observed production state now keeps phase two from repeating discovery work and makes the ownership, SELinux, static-config, Quadlet, secret-driver cleanup, validation, and rollback requirements explicit.

## Impact

This PR changes documentation only. Rootful Caddy remains the active edge proxy, and `quadlets/caddy.toml` remains disabled until the phase-two reboot-based cutover is implemented.

## Validation

- `git diff --check`
- confirmed the branch contains only commit `34bf3b2`
- production marker reported as `preflight_complete=yes`